### PR TITLE
chore: force Node.js 24 runtime for GitHub Actions

### DIFF
--- a/.github/workflows/scrape-events.yml
+++ b/.github/workflows/scrape-events.yml
@@ -9,6 +9,9 @@ on:
 permissions:
   contents: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   scheduled:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Add `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` as a top-level environment variable to all GitHub Actions workflow files in this repository.

## Why

GitHub Actions is migrating from Node.js 20 to Node.js 24 as the default runtime for JavaScript-based actions. Setting this environment variable opts workflows into using Node.js 24 now, ensuring:

- **Early compatibility** — surfaces any issues with the Node.js 24 runtime before it becomes the default
- **Consistent behavior** — all JavaScript actions in the workflow will use Node.js 24 regardless of what the action specifies
- **Future-proofing** — avoids unexpected breakage when GitHub completes the migration

## Changes

- Added `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` to the top-level `env:` block of each workflow file
- No other workflow logic was modified